### PR TITLE
Add jellyfin-encoder to Native section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,7 @@ FFmpeg's official docs are notoriously difficult for beginners to understand due
 ## Native
 
 - [ffmpeg-gl-transition](https://github.com/transitive-bullshit/ffmpeg-gl-transition) - FFmpeg filter for applying GLSL transitions between video streams ([gl-transitions](https://gl-transitions.com/)).
-
-
 - [jellyfin-encoder](https://github.com/GeiserX/jellyfin-encoder) - Automatic 720p HEVC/AV1 transcoding service for Jellyfin with NVIDIA and Intel hardware acceleration.
-
 
 ## Mobile
 

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,9 @@ FFmpeg's official docs are notoriously difficult for beginners to understand due
 - [ffmpeg-gl-transition](https://github.com/transitive-bullshit/ffmpeg-gl-transition) - FFmpeg filter for applying GLSL transitions between video streams ([gl-transitions](https://gl-transitions.com/)).
 
 
+- [jellyfin-encoder](https://github.com/GeiserX/jellyfin-encoder) - Automatic 720p HEVC/AV1 transcoding service for Jellyfin with NVIDIA and Intel hardware acceleration.
+
+
 ## Mobile
 
 - [simplest ffmpeg mobile](https://github.com/leixiaohua1020/simplest_ffmpeg_mobile) - FFmpeg examples for Android and iOS.


### PR DESCRIPTION
## Summary
- Adds [jellyfin-encoder](https://github.com/GeiserX/jellyfin-encoder) to the Native section
- jellyfin-encoder is an automatic 720p HEVC/AV1 transcoding service for Jellyfin with NVIDIA and Intel hardware acceleration