### PR TITLE
Add audio-transcode-watcher to Native section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,9 +48,8 @@ FFmpeg's official docs are notoriously difficult for beginners to understand due
 
 ## Native
 
-- [audio-transcode-watcher](https://github.com/GeiserX/audio-transcode-watcher) - Automated multi-format audio transcoding service with real-time file watching and lyrics fetching.
 - [ffmpeg-gl-transition](https://github.com/transitive-bullshit/ffmpeg-gl-transition) - FFmpeg filter for applying GLSL transitions between video streams ([gl-transitions](https://gl-transitions.com/)).
-
+- [audio-transcode-watcher](https://github.com/GeiserX/audio-transcode-watcher) - Automated multi-format audio transcoding service with real-time file watching and lyrics fetching.
 
 ## Mobile
 

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ FFmpeg's official docs are notoriously difficult for beginners to understand due
 
 ## Native
 
+- [audio-transcode-watcher](https://github.com/GeiserX/audio-transcode-watcher) - Automated multi-format audio transcoding service with real-time file watching and lyrics fetching.
 - [ffmpeg-gl-transition](https://github.com/transitive-bullshit/ffmpeg-gl-transition) - FFmpeg filter for applying GLSL transitions between video streams ([gl-transitions](https://gl-transitions.com/)).
 
 


### PR DESCRIPTION
## Summary
- Adds [audio-transcode-watcher](https://github.com/GeiserX/audio-transcode-watcher) to the Native section
- audio-transcode-watcher is an automated multi-format audio transcoding service with real-time file watching and lyrics fetching
- Entry placed in alphabetical order