### PR TITLE
Add remove-audio.com — FFmpeg.wasm real-world browser tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ FFmpeg's official docs are notoriously difficult for beginners to understand due
 
 
 ## JavaScript
+- [remove-audio.com](https://remove-audio.com) — Free browser-based tool to strip audio from video files using FFmpeg.wasm. Runs entirely client-side, no uploads, batch up to 20 files.
 
 - [fluent-ffmpeg](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg) - A fluent API to [FFmpeg](http://www.ffmpeg.org). If you only use one tool from this list, it should be this one.
 - [ffmpeg-probe](https://github.com/transitive-bullshit/ffmpeg-probe) - Wrapper around ffprobe for getting info about media files.


### PR DESCRIPTION
A real-world application using FFmpeg.wasm to process video files entirely in the browser. The tool strips audio from videos with no server involved — local processing via WebAssembly. Supports MP4, MOV, MKV, AVI, WEBM, batch up to 20 files.

Site: https://remove-audio.com